### PR TITLE
8.1.x

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -44,7 +44,7 @@ PRODUCT_PACKAGES += \
     init.target.rc
 
 # Devive Arch
-TARGET_ARM=arm
+TARGET_ARCH=arm
 
 # Inherit common stuff
     $(call inherit-product, vendor/aosp/config/common_full_phone.mk)

--- a/init/init_osprey.cpp
+++ b/init/init_osprey.cpp
@@ -95,6 +95,17 @@ void vendor_load_properties()
         property_set("dalvik.vm.heapminfree", "2m");
         property_set("dalvik.vm.heapmaxfree", "8m");
         gb[0] = 0;
+
+         /*
+	 * Set Go Properties for 1GB ram devices
+	 * Properties taken from build/target/product/go_defaults_common.mk
+	 */
+
+	property_override("ro.config.low_ram", "true");
+	property_override("ro.lmk.critical_upgrade", "true");
+        property_override("ro.lmk.upgrade_pressure", "40");
+	property_override("pm.dexopt.downgrade_after_inactive_days", "10");
+        property_override("pm.dexopt.shared", "quicken");
     }
 
     property_set("ro.gsm.data_retry_config", "default_randomization=2000,max_retries=infinite,1000,1000,80000,125000,485000,905000");


### PR DESCRIPTION

GAAPS_ARCH Fix


osprey: init: Mark 1GB deices with android go properties